### PR TITLE
Include the repository field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.6.0"
 edition = "2021"
 description = "Wrapper around socket functionality to make using devices safer and easier"
 license = "MIT"
+repository = "https://github.com/Larmbs/easy_esp"
 
 [lib]
 name = "easy_esp"


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.